### PR TITLE
fixes #5: improve autofix

### DIFF
--- a/lib/rules/no-smart-quotes.js
+++ b/lib/rules/no-smart-quotes.js
@@ -78,7 +78,7 @@ module.exports = {
                     }
 
                     return [
-                        fixer.replaceTextRange([node.start, node.end], fixed),
+                        fixer.replaceText(node, fixed),
                     ];
                 },
             });


### PR DESCRIPTION
For whatever reason `node.start` / `node.end` are not defined when running the rule in my project. This seems to cause the auto-fix to turn the code into garbage.

Instead, use the equivalent `fixer.replaceText(node, content)` that is recommended here: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-replace-text.md

Unfortunately I couldn't replicate the issue in your test suite, but the existing test suite continues to pass, and the autofix now behaves correctly on my project.

Debug output: (`console.log(node)`)
```
{
  type: 'Literal',
  raw: '...',
  value: '...',
  range: [ 843, 913 ],
  loc: { start: { line: 31, column: 15 }, end: { line: 31, column: 85 } },
  parent: {
    type: 'VariableDeclarator',
    id: {
      type: 'Identifier',
      name: 'test',
      range: [Array],
      loc: [Object],
      parent: [Circular]
    },
    init: [Circular],
    range: [ 836, 913 ],
    loc: { start: [Object], end: [Object] },
    parent: {
      type: 'VariableDeclaration',
      declarations: [Array],
      kind: 'const',
      range: [Array],
      loc: [Object],
      parent: [Object]
    }
  }
}
```

```
{
  type: 'JSXText',
  value: '...',
  raw: '...',
  range: [ 1670, 1787 ],
  loc: { start: { line: 54, column: 74 }, end: { line: 57, column: 10 } },
  parent: {
    type: 'JSXElement',
    openingElement: {
      type: 'JSXOpeningElement',
      typeParameters: undefined,
      selfClosing: false,
      name: [Object],
      attributes: [Array],
      range: [Array],
      loc: [Object],
      parent: [Circular]
    },
    closingElement: {
      type: 'JSXClosingElement',
      name: [Object],
      range: [Array],
      loc: [Object],
      parent: [Circular]
    },
    children: [ [Circular] ],
    range: [ 1606, 1794 ],
    loc: { start: [Object], end: [Object] },
    parent: {
      type: 'JSXElement',
      openingElement: [Object],
      closingElement: [Object],
      children: [Array],
      range: [Array],
      loc: [Object],
      parent: [Object]
    }
  }
}
```